### PR TITLE
Fix: Generate replication file when replication is selected in ktype

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -44,7 +44,7 @@ module.exports = yeoman.generators.Base.extend({
           {'name': this.props.kname}
         );
       }
-      if (this.props.ktype === 'both' || this.props.ktype === 'service') {
+      if (this.props.ktype === 'both' || this.props.ktype === 'replication') {
         this.fs.copyTpl(
           this.templatePath('_rc.yml'),
           this.destinationPath('rc.yml'),


### PR DESCRIPTION
When we select service as ktype, replicaset was also being created. This PR should fix that